### PR TITLE
StringTemplate.toString escape tab etc

### DIFF
--- a/src/main/java/walkingkooka/template/StringTemplate.java
+++ b/src/main/java/walkingkooka/template/StringTemplate.java
@@ -57,6 +57,9 @@ final class StringTemplate implements Template {
 
     @Override
     public String toString() {
-        return this.text;
+        return this.text.replace("\\", "\\\\")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
     }
 }

--- a/src/test/java/walkingkooka/template/StringTemplateTest.java
+++ b/src/test/java/walkingkooka/template/StringTemplateTest.java
@@ -76,6 +76,38 @@ public final class StringTemplateTest implements TemplateTesting2<StringTemplate
         );
     }
 
+    @Test
+    public void testToStringEscapesBackslash() {
+        this.toStringAndCheck(
+                StringTemplate.with("Hello\\"),
+                "Hello\\\\"
+        );
+    }
+
+    @Test
+    public void testToStringEscapesCarriageReturn() {
+        this.toStringAndCheck(
+                StringTemplate.with("Hello\r"),
+                "Hello\\r"
+        );
+    }
+
+    @Test
+    public void testToStringEscapesNewLine() {
+        this.toStringAndCheck(
+                StringTemplate.with("Hello\n"),
+                "Hello\\n"
+        );
+    }
+
+    @Test
+    public void testToStringEscapesTab() {
+        this.toStringAndCheck(
+                StringTemplate.with("Hello\t"),
+                "Hello\\t"
+        );
+    }
+
     // class............................................................................................................
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-template/issues/19
- StringTemplate.toString should escape raw text