### PR TITLE
BasicTemplateContext.templateValue accepting TemplateValueName to Exp…

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -66,7 +66,8 @@ public class TestGwtTest extends GWTTestCase {
                         TemplateValueName.parse(t)
                                 .orElseThrow(() -> new EmptyTextException("template value name"))
                 ),
-                (n) -> "<<" + n.text().toUpperCase() + ">>",
+                (n) -> Templates.string("<<" + n.text().toUpperCase() + ">>"),
+                LineEnding.NL,
                 ExpressionEvaluationContexts.basic(
                         expressionNumberKind,
                         (n) -> {

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -80,7 +80,8 @@ public class JunitTest {
                         TemplateValueName.parse(t)
                                 .orElseThrow(() -> new EmptyTextException("template value name"))
                 ),
-                (n) -> "<<" + n.text().toUpperCase() + ">>",
+                (n) -> Templates.string("<<" + n.text().toUpperCase() + ">>"),
+                LineEnding.NL,
                 ExpressionEvaluationContexts.basic(
                         expressionNumberKind,
                         (n) -> {

--- a/src/main/java/walkingkooka/template/BasicTemplateContextCycleTemplateContext.java
+++ b/src/main/java/walkingkooka/template/BasicTemplateContextCycleTemplateContext.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.template;
+
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionReference;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps another {@link TemplateContext} and if a {@link TemplateValueName} returned {@link Template} references to the same {@link TemplateValueName}.
+ */
+final class BasicTemplateContextCycleTemplateContext implements TemplateContext {
+
+    static BasicTemplateContextCycleTemplateContext with(final BasicTemplateContext context) {
+        return new BasicTemplateContextCycleTemplateContext(
+                Objects.requireNonNull(context, "context")
+        );
+    }
+
+    private BasicTemplateContextCycleTemplateContext(final BasicTemplateContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public Template parse(final TextCursor text) {
+        return this.context.parse(text);
+    }
+
+    @Override
+    public Template expression(final TextCursor text) {
+        return this.context.expression(text);
+    }
+
+    @Override
+    public String evaluate(final Expression expression) {
+        final ExpressionEvaluationContext context = this.context.expressionEvaluationContext;
+
+        return context.convertOrFail(
+                context.context(this::scopedExpressionReference)
+                        .evaluate(expression),
+                String.class
+        );
+    }
+
+    private Optional<Optional<Object>> scopedExpressionReference(final ExpressionReference reference) {
+        Optional<Optional<Object>> result;
+
+        if (reference instanceof TemplateValueName) {
+            result = Optional.of(
+                    Optional.of(
+                            this.templateValue((TemplateValueName) reference)
+                    )
+            );
+        } else {
+            result = this.context.expressionEvaluationContext.reference(reference);
+        }
+
+        return result;
+    }
+
+    @Override
+    public String templateValue(final TemplateValueName name) {
+        Objects.requireNonNull(name, "name");
+
+        final Set<TemplateValueName> cycles = this.cycles;
+        if (false == cycles.add(name)) {
+            // TODO introduce custom exception with a Set<TemplateValueName> property
+            final String separator = " -> ";
+
+            // Cycle detected \"Abc\" -> \"Def\" -> \"Ghi\" -> \"Abc\"
+            throw new IllegalStateException(
+                    "Cycle detected " +
+                            cycles.stream()
+                                    .map(TemplateValueName::nameInQuotes)
+                                    .collect(Collectors.joining(separator)) +
+                            separator +
+                            name.nameInQuotes()
+            );
+        }
+
+        final BasicTemplateContext context = this.context;
+        final Template template = context.nameToTemplate.apply(name);
+        if (null == template) {
+            throw new IllegalStateException("Missing template for " + name);
+        }
+
+        final String rendered = template.renderToString(
+                context.lineEnding,
+                this
+        );
+
+        cycles.remove(name);
+
+        return rendered;
+    }
+
+    // @see BasicTemplateContext
+    final Set<TemplateValueName> cycles = new LinkedHashSet<>();
+
+    private final BasicTemplateContext context;
+
+    @Override
+    public String toString() {
+        return this.context.toString();
+    }
+}

--- a/src/main/java/walkingkooka/template/TemplateContexts.java
+++ b/src/main/java/walkingkooka/template/TemplateContexts.java
@@ -18,6 +18,7 @@
 package walkingkooka.template;
 
 import walkingkooka.reflect.PublicStaticHelper;
+import walkingkooka.text.LineEnding;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
@@ -32,11 +33,13 @@ public final class TemplateContexts implements PublicStaticHelper {
      * {@see BasicTemplateContext}
      */
     public static TemplateContext expressionTemplateValueName(final Function<TextCursor, Template> expressionParser,
-                                                              final Function<TemplateValueName, String> nameToValue,
+                                                              final Function<TemplateValueName, Template> nameToTemplate,
+                                                              final LineEnding lineEnding,
                                                               final ExpressionEvaluationContext expressionEvaluationContext) {
         return BasicTemplateContext.with(
                 expressionParser,
-                nameToValue,
+                nameToTemplate,
+                lineEnding,
                 expressionEvaluationContext
         );
     }

--- a/src/main/java/walkingkooka/template/TemplateValueName.java
+++ b/src/main/java/walkingkooka/template/TemplateValueName.java
@@ -24,11 +24,14 @@ import walkingkooka.naming.Name;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserContexts;
 import walkingkooka.text.cursor.parser.Parsers;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.expression.function.ExpressionFunctionParameterName;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -36,7 +39,9 @@ import java.util.Optional;
 /**
  * The name of an template variable value. Names must start with a letter, followed by letters/digits/dash and are case-sensitive.
  */
-final public class TemplateValueName implements Name, Comparable<TemplateValueName> {
+final public class TemplateValueName implements Name,
+        Comparable<TemplateValueName>,
+        ExpressionReference {
 
     /**
      * Names must start with a letter.
@@ -114,6 +119,10 @@ final public class TemplateValueName implements Name, Comparable<TemplateValueNa
 
     private final String name;
 
+    CharSequence nameInQuotes() {
+        return CharSequences.quoteAndEscape(this.name);
+    }
+
     // Comparable........................................................................................................
 
     @Override
@@ -151,4 +160,16 @@ final public class TemplateValueName implements Name, Comparable<TemplateValueNa
     }
 
     public final static CaseSensitivity CASE_SENSITIVITY = CaseSensitivity.SENSITIVE;
+
+    // ExpressionReference..............................................................................................
+
+    @Override
+    public boolean testParameterName(final ExpressionFunctionParameterName parameterName) {
+        Objects.requireNonNull(parameterName, "parameterName");
+
+        return CASE_SENSITIVITY.equals(
+                this.value(),
+                parameterName.value()
+        );
+    }
 }

--- a/src/test/java/walkingkooka/template/BasicTemplateContextCycleTemplateContextTest.java
+++ b/src/test/java/walkingkooka/template/BasicTemplateContextCycleTemplateContextTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.template;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class BasicTemplateContextCycleTemplateContextTest implements ClassTesting<BasicTemplateContextCycleTemplateContext> {
+
+    @Override
+    public Class<BasicTemplateContextCycleTemplateContext> type() {
+        return BasicTemplateContextCycleTemplateContext.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/template/TemplateTest.java
+++ b/src/test/java/walkingkooka/template/TemplateTest.java
@@ -38,8 +38,9 @@ public final class TemplateTest implements TemplateTesting, ClassTesting<Templat
                 ),
                 Maps.of(
                         TemplateValueName.with("abc"),
-                        "111"
+                        Templates.string("111")
                 )::get,
+                LineEnding.NL,
                 ExpressionEvaluationContexts.fake()
         );
 

--- a/src/test/java/walkingkooka/template/sample/Sample.java
+++ b/src/test/java/walkingkooka/template/sample/Sample.java
@@ -55,7 +55,8 @@ public class Sample {
                         TemplateValueName.parse(t)
                                 .orElseThrow(() -> new EmptyTextException("template value name"))
                 ),
-                (n) -> "<<" + n.text().toUpperCase() + ">>",
+                (n) -> Templates.string("<<" + n.text().toUpperCase() + ">>"),
+                LineEnding.NL,
                 ExpressionEvaluationContexts.basic(
                         expressionNumberKind,
                         (n) -> {


### PR DESCRIPTION
…ression

- Previously a function mapping TemplateValueName -> String was given, this has been replaced by TemplateValueName -> Expression.
 - The expression can include maths, functions or references to other TemplateValueName.
- Cycles are detected and an IllegalStateException thrown.