### PR TITLE
TemplateContext.evaluateAsString was evaluate

### DIFF
--- a/src/main/java/walkingkooka/template/BasicTemplateContext.java
+++ b/src/main/java/walkingkooka/template/BasicTemplateContext.java
@@ -90,9 +90,9 @@ final class BasicTemplateContext implements TemplateContext {
     private final Function<TextCursor, Template> expressionParser;
 
     @Override
-    public String evaluate(final Expression expression) {
+    public String evaluateAsString(final Expression expression) {
         return BasicTemplateContextCycleTemplateContext.with(this)
-                .evaluate(expression);
+                .evaluateAsString(expression);
     }
 
     // see BasicTemplateContextCycleTemplateContext

--- a/src/main/java/walkingkooka/template/BasicTemplateContextCycleTemplateContext.java
+++ b/src/main/java/walkingkooka/template/BasicTemplateContextCycleTemplateContext.java
@@ -54,7 +54,7 @@ final class BasicTemplateContextCycleTemplateContext implements TemplateContext 
     }
 
     @Override
-    public String evaluate(final Expression expression) {
+    public String evaluateAsString(final Expression expression) {
         final ExpressionEvaluationContext context = this.context.expressionEvaluationContext;
 
         return context.convertOrFail(

--- a/src/main/java/walkingkooka/template/ExpressionTemplate.java
+++ b/src/main/java/walkingkooka/template/ExpressionTemplate.java
@@ -44,7 +44,7 @@ final class ExpressionTemplate implements Template {
         Objects.requireNonNull(context, "context");
 
         printer.print(
-                context.evaluate(this.expression)
+                context.evaluateAsString(this.expression)
         );
     }
 

--- a/src/main/java/walkingkooka/template/FakeTemplateContext.java
+++ b/src/main/java/walkingkooka/template/FakeTemplateContext.java
@@ -37,7 +37,7 @@ public class FakeTemplateContext implements TemplateContext {
     }
 
     @Override
-    public String evaluate(final Expression expression) {
+    public String evaluateAsString(final Expression expression) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/template/TemplateContext.java
+++ b/src/main/java/walkingkooka/template/TemplateContext.java
@@ -102,7 +102,7 @@ public interface TemplateContext extends Context {
     /**
      * Evaluates the given {@link Expression} into a {@link String string value}
      */
-    String evaluate(final Expression expression);
+    String evaluateAsString(final Expression expression);
 
     /**
      * Resolves the given {@link TemplateValueName} into a {@link String}. When the value is not found,

--- a/src/main/java/walkingkooka/template/TemplateContextTesting.java
+++ b/src/main/java/walkingkooka/template/TemplateContextTesting.java
@@ -130,14 +130,14 @@ public interface TemplateContextTesting<C extends TemplateContext> extends Conte
         );
     }
 
-    // evaluateAndCheck.................................................................................................
+    // evaluateAsString.................................................................................................
 
-    default void evaluateAndCheck(final TemplateContext context,
-                                  final Expression expression,
-                                  final String expected) {
+    default void evaluateAsStringAndCheck(final TemplateContext context,
+                                          final Expression expression,
+                                          final String expected) {
         this.checkEquals(
                 expected,
-                context.evaluate(expression)
+                context.evaluateAsString(expression)
         );
     }
 

--- a/src/main/java/walkingkooka/template/TemplateContextTesting2.java
+++ b/src/main/java/walkingkooka/template/TemplateContextTesting2.java
@@ -173,14 +173,14 @@ public interface TemplateContextTesting2<C extends TemplateContext> extends Temp
         );
     }
 
-    // evaluate.........................................................................................................
+    // evaluateAsString.................................................................................................
 
-    default void evaluateAndCheck(final Expression expression,
-                                  final String expected) {
+    default void evaluateAsStringAndCheck(final Expression expression,
+                                          final String expected) {
         this.checkEquals(
                 expected,
                 this.createContext()
-                        .evaluate(expression)
+                        .evaluateAsString(expression)
         );
     }
 

--- a/src/test/java/walkingkooka/template/TemplateContextTesting2Test.java
+++ b/src/test/java/walkingkooka/template/TemplateContextTesting2Test.java
@@ -131,7 +131,7 @@ public final class TemplateContextTesting2Test implements TemplateContextTesting
                     }
 
                     @Override
-                    public String evaluate(final Expression expression) {
+                    public String evaluateAsString(final Expression expression) {
                         return ExpressionEvaluationContexts.basic(
                                         expressionNumberKind,
                                         (n) -> {
@@ -372,7 +372,7 @@ public final class TemplateContextTesting2Test implements TemplateContextTesting
         }
 
         @Override
-        public String evaluate(final Expression expression) {
+        public String evaluateAsString(final Expression expression) {
             Objects.requireNonNull(expression, "parseTemplateExpression");
 
             throw new UnsupportedOperationException();


### PR DESCRIPTION
- Previous generic name could cause clashes with other Context like interfaces.