### PR TITLE
UrlPathTemplateValues.get lookup FIX

### DIFF
--- a/src/main/java/walkingkooka/template/url/UrlPathTemplateValues.java
+++ b/src/main/java/walkingkooka/template/url/UrlPathTemplateValues.java
@@ -70,7 +70,7 @@ public final class UrlPathTemplateValues implements Value<List<Object>>,
                 continue;
             }
 
-            if (component instanceof TemplateValueName) {
+            if (name.equals(component)) {
                 final UrlPathName pathComponent = this.pathComponents.get(pathComponentIndex);
                 if (null != pathComponent) {
                     final String stringValue = pathComponent.value();
@@ -98,8 +98,6 @@ public final class UrlPathTemplateValues implements Value<List<Object>>,
                     if (pathComponentIndex > 0 && UrlPathTemplate.PATH_SEPARATOR_STRING.equals(component)) {
                         pathComponentIndex--;
                     }
-                } else {
-                    throw new IllegalStateException("Unknown template component " + component);
                 }
             }
 

--- a/src/test/java/walkingkooka/template/url/UrlPathTemplateValuesTest.java
+++ b/src/test/java/walkingkooka/template/url/UrlPathTemplateValuesTest.java
@@ -142,6 +142,26 @@ public final class UrlPathTemplateValuesTest implements TreePrintableTesting,
         );
     }
 
+    @Test
+    public void testGetValueMultiple() {
+        this.getAndCheck(
+            "${value1}/${value2}",
+            "1111/2222",
+            "value1",
+            1111
+        );
+    }
+
+    @Test
+    public void testGetValueMultiple2() {
+        this.getAndCheck(
+            "${value1}/${value2}",
+            "1111/2222",
+            "value2",
+            2222
+        );
+    }
+
     private void getAndCheck(final String template,
                              final String path,
                              final String name) {


### PR DESCRIPTION
- Previous version didnt actually compare the given name with the component name as it was scanning. This is now fixed.