### PR TITLE
UrlPathTemplate slash optional when template-value-name ending

### DIFF
--- a/src/test/java/walkingkooka/template/url/UrlPathTemplateTest.java
+++ b/src/test/java/walkingkooka/template/url/UrlPathTemplateTest.java
@@ -655,6 +655,22 @@ public final class UrlPathTemplateTest implements TemplateTesting2<UrlPathTempla
     }
 
     @Test
+    public void testTryPrepareValuesWithPathComponentValueComponentMissingLast() {
+        this.tryPrepareValuesAndCheck(
+            "path1/${value2}/path3",
+            "path1/path2/"
+        );
+    }
+
+    @Test
+    public void testTryPrepareValuesWithPathComponentValueComponentMissingLast2() {
+        this.tryPrepareValuesAndCheck(
+            "path1/${value2}/path3",
+            "path1/path2"
+        );
+    }
+
+    @Test
     public void testTryPrepareValuesWithPathComponentValueComponentExtraComponent() {
         this.tryPrepareValuesAndCheck(
             "path1/${value2}",
@@ -668,7 +684,7 @@ public final class UrlPathTemplateTest implements TemplateTesting2<UrlPathTempla
     @Test
     public void testTryPrepareValuesWithPathComponentValueComponentSlash() {
         this.tryPrepareValuesAndCheck(
-            "/path1/${value2}/${value3}/",
+            "/path1/${value2}/${value3}/", // slash required
             "/path1/path2/path3"
         );
     }
@@ -685,6 +701,18 @@ public final class UrlPathTemplateTest implements TemplateTesting2<UrlPathTempla
             VALUE3
         );
     }
+
+    @Test
+    public void testTryPrepareValuesWithPathComponentPathMissingLastSlash() {
+        this.tryPrepareValuesAndCheck(
+            "path1/${value2}",
+            "path1", // path
+            "path1", // template components
+            PATH_SEPARATOR,
+            VALUE2
+        );
+    }
+
     private void tryPrepareValuesAndCheck(final String template,
                                           final String path) {
         this.tryPrepareValuesAndCheck(

--- a/src/test/java/walkingkooka/template/url/UrlPathTemplateValuesTest.java
+++ b/src/test/java/walkingkooka/template/url/UrlPathTemplateValuesTest.java
@@ -196,6 +196,39 @@ public final class UrlPathTemplateValuesTest implements TreePrintableTesting,
     }
 
     @Test
+    public void testGetLastValueEmpty() {
+        this.getAndCheck(
+            "path1/${last}",
+            "path1/",
+            "last",
+            (s) -> s,
+            "/"
+        );
+    }
+
+    @Test
+    public void testGetLastValueMissingSlash() {
+        this.getAndCheck(
+            "path1/${last}",
+            "path1",
+            "last",
+            (s) -> s,
+            ""
+        );
+    }
+
+    @Test
+    public void testGetLastValueMissingSlash2() {
+        this.getAndCheck(
+            "path1/path2/${last}",
+            "path1/path2",
+            "last",
+            (s) -> s,
+            ""
+        );
+    }
+
+    @Test
     public void testGetSlashLastValue() {
         this.getAndCheck(
             "/${last}",
@@ -225,6 +258,39 @@ public final class UrlPathTemplateValuesTest implements TreePrintableTesting,
             "last",
             (s) -> s,
             "/2222/3333/4444"
+        );
+    }
+
+    @Test
+    public void testGetSlashLastValueEmpty() {
+        this.getAndCheck(
+            "/path1/${last}",
+            "/path1/",
+            "last",
+            (s) -> s,
+            "/"
+        );
+    }
+
+    @Test
+    public void testGetSlashLastValueMissingSlash() {
+        this.getAndCheck(
+            "/path1/${last}",
+            "/path1",
+            "last",
+            (s) -> s,
+            ""
+        );
+    }
+
+    @Test
+    public void testGetSlashLastValueMissingSlash2() {
+        this.getAndCheck(
+            "/path1/path2/${last}",
+            "/path1/path2",
+            "last",
+            (s) -> s,
+            ""
         );
     }
 


### PR DESCRIPTION
- /path1/path2/${value2}
- matches both
- /path1/path2
- /path1/path2/path3